### PR TITLE
fix: remove unnecessary checkbox value

### DIFF
--- a/templates/scaffold/fields/checkbox.stub
+++ b/templates/scaffold/fields/checkbox.stub
@@ -3,6 +3,6 @@
     {!! Form::label('$FIELD_NAME$', '$FIELD_NAME_TITLE$:') !!}
     <label class="checkbox-inline">
         {!! Form::hidden('$FIELD_NAME$', 0) !!}
-        {!! Form::checkbox('$FIELD_NAME$', '$CHECKBOX_VALUE$', null) !!} $CHECKBOX_VALUE$
+        {!! Form::checkbox('$FIELD_NAME$', '$CHECKBOX_VALUE$', null) !!}
     </label>
 </div>


### PR DESCRIPTION
### What change done?

The value of the checkbox should not be printed unless specified.
https://github.com/InfyOmLabs/laravel-generator/issues/730